### PR TITLE
Fix output assignment 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ outputs:
   scenarios:
     description: "List of Molecule scenarios"
 runs:
-  using: node12
+  using: node16
   main: index.js

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ async function run() {
 
     if (scenarios.length) {
       process.stdout.write(
-        `scenarios=${JSON.stringify(scenarios)}\n >> $GITHUB_OUTPUT`
+        `scenarios=${JSON.stringify(scenarios)} >> $GITHUB_OUTPUT`
       );
     } else {
       throw "No scenarios found!";

--- a/index.js
+++ b/index.js
@@ -26,9 +26,7 @@ async function run() {
     process.stdout.write(`Found scenarios ${scenarios}\n`);
 
     if (scenarios.length) {
-      process.stdout.write(
-        `scenarios=${JSON.stringify(scenarios)} >> $GITHUB_OUTPUT`
-      );
+      fs.appendFileSync(process.env.GITHUB_OUTPUT, `scenarios=${JSON.stringify(scenarios)}\n`);
     } else {
       throw "No scenarios found!";
     }


### PR DESCRIPTION
See e.g. https://github.com/IDR/ansible-role-openstack-idr-instance/actions/runs/3357163854/attempts/1

All GitHub workflows using this action are currently failing when evaluating the output of the first action to create the matrix of tests. 
After a bit of investigation, this is another variant of the changes documented in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ and which have been also fixed across the board - see e.g. https://github.com/ome/bioformats/pull/3893/files

This PR also updates `node12` to `node16` as per the deprecation of the former - see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12